### PR TITLE
Fixed dependency reference in Getting Started _index.md

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -16,7 +16,7 @@ Including ```mavenLocal()``` is optional, if you want to use pre-release builds 
 
 Include Koala Plot core as a dependency in your project's build.gradle.kts
 
-{{% code "/examples/build.gradle.kts" 29 29 %}}
+{{% code "/examples/build.gradle.kts" 30 30 %}}
 
 You can also see a complete example of a build.gradle.kts in the [samples](https://github.com/KoalaPlot/koalaplot-samples/blob/main/build.gradle.kts).
 


### PR DESCRIPTION
As the line numbering probably changed, the static line reference in the Getting Started guide got messed up so that a Compose UI dependency is shown instead of the actual KoalaPlot dependency, see https://koalaplot.github.io/docs/getting-started/