### PR TITLE
Update Bar plots to reflect the deprecation of DefaultVerticalBar

### DIFF
--- a/content/en/docs/xygraphs/bar_plots/index.md
+++ b/content/en/docs/xygraphs/bar_plots/index.md
@@ -10,19 +10,19 @@ Bar Plots are also 2-D plots and are therefore plotted within an ```XYGraph``` p
 
 The simplest type of vertical bar plot has a single series of data, and there is a ```VerticalBarPlot``` overload to make this use case easy when using Float values for the y-axis. The below example demonstrates this to plot the population of each New York City burrough.
 
-{{% example "/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar1.kt" 16 31 %}}
+{{% example "/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar1.kt" 14 35 %}}
 ![Vertical bars](VerticalBar1.png)
 {{% /example %}}
 
 In the above example, all bars were automatically extended to the origin of the y-axis, 0. In some cases it is desirable to plot vertical bars with starting positions that are not at 0. To support this use case, there is a second form of ```VerticalBarPlot``` that allows specifying the starting and ending coordinates of each bar. The below example demonstrates using this flexibility to create a waterfall chart:
 
-{{% example "/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar2.kt" 17 39 %}}
+{{% example "/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar2.kt" 17 53 %}}
 ![Waterfall](VerticalBar2.png)
 {{% /example %}}
 
 There is also a builder DSL for vertical bar plots, that slightly improves on the syntax. The previous example can also be implemented as follows:
 
-{{% code "/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar3.kt" 15 29  %}}
+{{% code "/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar3.kt" 17 29  %}}
 
 {{% alert title="Tip" color="info" %}}
 For improved type safety, consider using an enumeration for the ```CategoryAxisModel``` categories. If an item is added with a category value that is not a member of the list provided to the ```CategoryAxisModel``` constructor, a runtime exception will be thrown.

--- a/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar1.kt
+++ b/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar1.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.window.singleWindowApplication
-import io.github.koalaplot.core.bar.DefaultVerticalBar
+import io.github.koalaplot.core.bar.DefaultBar
 import io.github.koalaplot.core.bar.VerticalBarPlot
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
 import io.github.koalaplot.core.xygraph.CategoryAxisModel
@@ -17,16 +17,19 @@ fun main() = singleWindowApplication {
     val population = listOf(1.446788f, 2.648452f, 1.638281f, 2.330295f, 0.487155f)
 
     XYGraph(
-        xAxisModel = remember { CategoryAxisModel(boroughs) },
-        yAxisModel = rememberFloatLinearAxisModel(0f..3f, minorTickCount = 0),
-        yAxisTitle = "Population (Millions)"
+            xAxisModel = remember { CategoryAxisModel(boroughs) },
+            yAxisModel = rememberFloatLinearAxisModel(0f..3f, minorTickCount = 0),
+            yAxisTitle = "Population (Millions)"
     ) {
         VerticalBarPlot(
-            xData = boroughs,
-            yData = population,
-            bar = {
-                DefaultVerticalBar(SolidColor(Color.Blue))
-            }
+                xData = boroughs,
+                yData = population,
+                bar = { _, _, _ ->
+                    DefaultBar(
+                            brush = SolidColor(Color.Blue),
+                            modifier = Modifier.fillMaxWidth(),
+                    )
+                }
         )
     }
 }

--- a/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar2.kt
+++ b/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar2.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.window.singleWindowApplication
-import io.github.koalaplot.core.bar.DefaultVerticalBar
+import io.github.koalaplot.core.bar.DefaultBar
 import io.github.koalaplot.core.bar.VerticalBarPlot
 import io.github.koalaplot.core.bar.verticalBarPlotEntry
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
@@ -17,26 +17,37 @@ import io.github.koalaplot.core.xygraph.rememberFloatLinearAxisModel
 @OptIn(ExperimentalKoalaPlotApi::class)
 fun main() = singleWindowApplication {
     val categories = listOf("Initial Cash", "Q1", "Q2", "Q3", "Q4", "Final Cash")
-    val colors = listOf(
-        Color.DarkGray, Color(0xFF00498F), Color(0xFFED7D31),
-        Color(0xFF00498F), Color(0xFF00498F), Color.DarkGray,
-    )
-    val data = listOf(
-        verticalBarPlotEntry(categories[0], 0f, 100f),
-        verticalBarPlotEntry(categories[1], 100f, 120f),
-        verticalBarPlotEntry(categories[2], 120f, 90f),
-        verticalBarPlotEntry(categories[3], 90f, 110f),
-        verticalBarPlotEntry(categories[4], 110f, 130f),
-        verticalBarPlotEntry(categories[5], 0f, 130f),
-    )
+    val colors =
+            listOf(
+                    Color.DarkGray,
+                    Color(0xFF00498F),
+                    Color(0xFFED7D31),
+                    Color(0xFF00498F),
+                    Color(0xFF00498F),
+                    Color.DarkGray,
+            )
+    val data =
+            listOf(
+                    verticalBarPlotEntry(categories[0], 0f, 100f),
+                    verticalBarPlotEntry(categories[1], 100f, 120f),
+                    verticalBarPlotEntry(categories[2], 120f, 90f),
+                    verticalBarPlotEntry(categories[3], 90f, 110f),
+                    verticalBarPlotEntry(categories[4], 110f, 130f),
+                    verticalBarPlotEntry(categories[5], 0f, 130f),
+            )
 
     XYGraph(
-        xAxisModel = remember { CategoryAxisModel(categories) },
-        yAxisModel = rememberFloatLinearAxisModel(0f..150f, minorTickCount = 0),
+            xAxisModel = remember { CategoryAxisModel(categories) },
+            yAxisModel = rememberFloatLinearAxisModel(0f..150f, minorTickCount = 0),
     ) {
         VerticalBarPlot(
-            data,
-            bar = { DefaultVerticalBar(SolidColor(colors[it])) }
+                data,
+                bar = { index, _, _ ->
+                    DefaultBar(
+                            brush = SolidColor(colors[index]),
+                            modifier = Modifier.fillMaxWidth(),
+                    )
+                }
         )
     }
 }

--- a/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar2.kt
+++ b/examples/src/jvmMain/kotlin/io/github/koalaplot/example/VerticalBar2.kt
@@ -55,11 +55,11 @@ fun main() = singleWindowApplication {
 @Composable
 private fun XYGraphScope<String, Float>.x() {
     VerticalBarPlot {
-        item("Initial Cash", 0f, 100f) { DefaultVerticalBar(SolidColor(Color.DarkGray)) }
-        item("Q1", 100f, 120f) { DefaultVerticalBar(SolidColor(Color(0xFF00498F))) }
-        item("Q2", 120f, 90f) { DefaultVerticalBar(SolidColor(Color(0xFFED7D31))) }
-        item("Q3", 90f, 110f) { DefaultVerticalBar(SolidColor(Color(0xFF00498F))) }
-        item("Q4", 110f, 130f) { DefaultVerticalBar(SolidColor(Color(0xFF00498F))) }
-        item("Final Cash", 0f, 130f) { DefaultVerticalBar(SolidColor(Color.DarkGray)) }
+        item("Initial Cash", 0f, 100f) { _, _, _ -> DefaultBar(SolidColor(Color.DarkGray)) }
+        item("Q1", 100f, 120f) { _, _, _ -> DefaultBar(SolidColor(Color(0xFF00498F))) }
+        item("Q2", 120f, 90f) { _, _, _ -> DefaultBar(SolidColor(Color(0xFFED7D31))) }
+        item("Q3", 90f, 110f) { _, _, _ -> DefaultBar(SolidColor(Color(0xFF00498F))) }
+        item("Q4", 110f, 130f) { _, _, _ -> DefaultBar(SolidColor(Color(0xFF00498F))) }
+        item("Final Cash", 0f, 130f) { _, _, _ -> DefaultBar(SolidColor(Color.DarkGray)) }
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+hugo-extended = "0.120.4"


### PR DESCRIPTION
Updated the examples in [Bar Plots](http://localhost:1313/docs/xygraphs/bar_plots/) to reflect `DefaultVerticalBar` being replaced with `DefaultBar` in version 0.10.0 see [here](https://github.com/KoalaPlot/koalaplot-core/blob/c00bb485e4d8e9aaa35728a7ac207a05502700e6/CHANGELOG.md#changed-2). Also adjusted the code block sizes to reflect the changes in the kotlin files.

Furthermore there is a need to specify the arguments to satisfy the argument type. Where they are not used I've made them annonymous.

Closes #4 